### PR TITLE
fix, use field name from options instead of _id

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ exports.mongoosePlugin = function (schema, options) {
             }
 
             exports.getNextSequence(doc.db.db, doc.collection.name, fieldName, function (err, result) {
-                doc._id = result;
+                doc[fieldName] = result;
                 next(err);
             });
         } else {


### PR DESCRIPTION
Hello,

Mongoose plugin ignores field name from options and/or default settings. This commit fixes this.
