### PR TITLE
Fix undefined result

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,11 @@ function getNextId(db, collectionName, fieldName, callback) {
                     callback(err);
                 }
             } else {
-                callback(null, result.seq);
+                if (result.value && result.value.seq) {
+                    callback(null, result.value.seq);
+                } else {
+                    callback(null, result.seq);
+                }
             }
         }
     );


### PR DESCRIPTION
Mongodb 3.0 + Mongoose 4.1.0

in result (index.js:125): 

     { 
          value: { _id: 'sclients', field: '_id', seq: 31 },
          lastErrorObject: { updatedExisting: true, n: 1 },
          ok: 1 
     }

(`seq` inside `value`)

May results be different depending on the client?