### PR TITLE
fix reference to incremented value

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function getNextId(db, collectionName, fieldName, callback) {
                     callback(err);
                 }
             } else {
-                callback(null, result.seq);
+                callback(null, result.value.seq);
             }
         }
     );
@@ -133,4 +133,3 @@ function getOption(collectionName, optionName) {
         settings[collectionName][optionName] :
         defaultSettings[optionName];
 }
-


### PR DESCRIPTION
Issue: The `result` object actually stores the sequence in `result.value.seq` - it's not top-level within `result.seq`.

Just a small reference fixes this! :smile: 