### PR TITLE
fix: corner case error when counters _id is duplicated

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,8 @@ function getNextId(db, collectionName, fieldName, callback) {
         function (err, result) {
             if (err) {
                 if (err.code == 11000) {
-                    process.nextTick(getNextId.bind(null, db, collectionName, fieldName, callback));
+                    if (err.message.indexOf('duplicate key') > -1) callback(err)
+                    else process.nextTick(getNextId.bind(null, db, collectionName, fieldName, callback));
                 } else {
                     callback(err);
                 }


### PR DESCRIPTION
The duplicate may from arguments passed from user:

``` javascript
    autoIncrement.getNextSequence(db, 'test', 'ID', function(e, ID) {})
    ... ...
    autoIncrement.getNextSequence(db, 'test', 'ID2', function(e, ID) {})

```

Before this PR, `ID2` will never show any errors, but the program hang, because the error message is:

```
{
  name: 'MongoError',
  message: 'E11000 duplicate key error index: test3.counters.$_id_ dup key: { : "test" }',
  ok: 0,
  errmsg: 'E11000 duplicate key error index: test3.counters.$_id_ dup key: { : "test" }',
  code: 11000
}
```
See, the error code is also `11000`, but should throw in this case.